### PR TITLE
fix: duplicate req objects

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -12,7 +12,8 @@ const internals = {
             req: ReqSerializer
         },
         ignorePaths: ['/health', '/healthcheck', '/metrics'],
-        exposeErrors: process.env.LOG_EXPOSE_ERRORS
+        exposeErrors: process.env.LOG_EXPOSE_ERRORS,
+        getChildBindings: () => ({})
     }
 };
 


### PR DESCRIPTION
tl;dr: *Logs were double-logging `req` objects and this fixes that bug

Long answer:

https://github.com/pinojs/hapi-pino/issues/91 points to this issue. The tests were not catching the bug because the plugin tests were parsing the logged strings to JSON. Pino strategically does not parse json as a performance optimization. Because the tests were parsing to JSON, the duplicate keys were removed in the parsing (masking the bug). I removed the JSON parse, and the tests failed (correctly) due to the duplicate object

We were double logging in our specific implementation because we parse and manually add the `req` object due to our own needs. This conflicted with the default request logger behavior in `hapi-pino` because it adds the `req` object every time, and we add a second `req` object which Pino happily marshals directly to a string, without testing if there is already a field for this

Sumo Logic is _not_ happy with this duplicate field and all queries on `req` or nested objects return nothing

In `hapi-pino` - we can see the child logger defaults here: https://github.com/pinojs/hapi-pino#optionsgetchildbindings-request---key-any- however it doesn't note that subsequent duplicate keys will be added. The core of this fix overrides the `getChildBindings` function to not include anything by default